### PR TITLE
Update openconfig-keychain-types.yang

### DIFF
--- a/release/models/keychain/openconfig-keychain-types.yang
+++ b/release/models/keychain/openconfig-keychain-types.yang
@@ -137,4 +137,22 @@ module openconfig-keychain-types {
       reference
         "RFC 4494 - The AES-CMAC-96 Algorithm and Its Use with IPsec";
   }
+
+  identity AES_128_CMAC {
+    base CRYPTO_TYPE;
+      description
+        "AES-128-CMAC keyed hash function based on a AES-128 block
+        cipher.";
+      reference
+        "RFC 4493 - The AES-CMAC Algorithm and Its Use with IPsec";
+  }
+
+  identity AES_256_CMAC {
+    base CRYPTO_TYPE;
+      description
+        "AES-256-CMAC keyed hash function based on a AES-256 block
+        cipher.";
+      reference
+        "RFC 4493 - The AES-CMAC Algorithm and Its Use with IPsec";
+  }
 }


### PR DESCRIPTION
Added AES_128_CMAC and AES_256_CMAC

[Note: Please fill out the following template for your pull request. lines
tagged with "Note" can be removed from the template.]

[Note: Before this PR can be reviewed please agree to the CLA covering this
repo. Please also review the contribution guide -
https://github.com/openconfig/public/blob/master/doc/external-contributions-guide.md]

### Change Scope

* [Please briefly describe the change that is being made to the models.]
* [Please indicate whether this change is backwards compatible.]
### Platform Implementations

 * Implementation A: [link to documentation](http://foo.com) and/or
   implementation output.
 * Implementation B: [link to documentation](http://foo.com) and/or
   implementation output.

[Note: Please provide at least two references to implementations which are relevant to the model changes proposed.  Each implementation should be from separate organizations.]. 

[Note: If the feature being proposed is new - and something that is being
proposed as an enhancement to device functionality, it is sufficient to have
reviewers from the producers of two different implementations].
